### PR TITLE
Added a helper for AccountSet transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evernode-js-client",
-    "version": "0.4.11",
+    "version": "0.4.12",
     "scripts": {
         "lint": "./node_modules/.bin/eslint src/**/*.js",
         "build": "npm run lint && ncc build src/index.js -e elliptic -e xrpl -e ripple-address-codec -e ripple-keypairs -o dist/",

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -56,14 +56,15 @@ class HostClient extends BaseEvernodeClient {
             this.xrplAcc.getTrustLines(EvernodeConstants.EVR, this.config.evrIssuerAddress),
             this.xrplAcc.getMessageKey()]);
 
-        if (!flags.lsfDefaultRipple)
-            await this.xrplAcc.setAccountFields({ Flags: { asfDefaultRipple : true } });
+        let accountSetFields = {};
+        accountSetFields =  (!flags.lsfDefaultRipple) ? { ...accountSetFields, Flags: {asfDefaultRipple : true }} : accountSetFields;
+        accountSetFields = (!msgKey) ? {...accountSetFields, MessageKey : this.accKeyPair.publicKey} : accountSetFields;
+
+        if (Object.keys(accountSetFields).length !== 0) 
+            await this.xrplAcc.setAccountFields(accountSetFields);
 
         if (trustLines.length === 0)
             await this.xrplAcc.setTrustLine(EvernodeConstants.EVR, this.config.evrIssuerAddress, "99999999999999");
-
-        if (!msgKey)
-            await this.xrplAcc.setAccountFields({ MessageKey : this.accKeyPair.publicKey });
     }
 
     async register(hostingToken, countryCode, cpuMicroSec, ramMb, diskMb, description, options = {}) {

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -57,13 +57,13 @@ class HostClient extends BaseEvernodeClient {
             this.xrplAcc.getMessageKey()]);
 
         if (!flags.lsfDefaultRipple)
-            await this.xrplAcc.setDefaultRippling(true);
+            await this.xrplAcc.setAccountFields({ Flags: { asfDefaultRipple : true } });
 
         if (trustLines.length === 0)
             await this.xrplAcc.setTrustLine(EvernodeConstants.EVR, this.config.evrIssuerAddress, "99999999999999");
 
         if (!msgKey)
-            await this.xrplAcc.setMessageKey(this.accKeyPair.publicKey);
+            await this.xrplAcc.setAccountFields({ MessageKey : this.accKeyPair.publicKey });
     }
 
     async register(hostingToken, countryCode, cpuMicroSec, ramMb, diskMb, description, options = {}) {

--- a/src/clients/user-client.js
+++ b/src/clients/user-client.js
@@ -29,7 +29,7 @@ class UserClient extends BaseEvernodeClient {
     async prepareAccount() {
         try {
             if (!await this.xrplAcc.getMessageKey())
-                await this.xrplAcc.setMessageKey(this.accKeyPair.publicKey);
+                await this.xrplAcc.setAccountFields({ MessageKey : this.accKeyPair.publicKey });
         }
         catch (err) {
             console.log("Error in preparing user xrpl account for Evernode.", err);

--- a/src/xrpl-account.js
+++ b/src/xrpl-account.js
@@ -123,6 +123,33 @@ class XrplAccount {
         return this.#submitAndVerifyTransaction(tx, options);
     }
 
+    setAccountFields(fields, options = {}) {
+        /**
+         * Example for fields
+         * 
+         * fields = [
+         * {"name" : "Domain", "value" : "6578616D706C652E636F6D"},
+         * {"name" : "SetFlag", "value" : 8}
+         * ]
+         */
+
+        if (fields.length === 0)
+            throw "AccountSet fields cannot be empty.";
+
+        const tx = {
+            TransactionType: 'AccountSet',
+            Account: this.address
+        };
+
+        fields.forEach(field => {
+            if (!tx.hasOwnProperty(field.name)) {
+                tx[field.name] = field.value;
+            }
+        });
+
+        return this.#submitAndVerifyTransaction(tx, options);
+    }
+
     makePayment(toAddr, amount, currency, issuer = null, memos = null, options = {}) {
 
         const amountObj = makeAmountObject(amount, currency, issuer);

--- a/src/xrpl-account.js
+++ b/src/xrpl-account.js
@@ -100,7 +100,6 @@ class XrplAccount {
     }
 
 
-
     setAccountFields(fields, options = {}) {
         /**
          * Example for fields
@@ -129,7 +128,7 @@ class XrplAccount {
 
                 case 'Flags' :
                     for (const [flagKey, flagValue] of Object.entries(value)) {
-                        tx[(flagValue) ? 'SetFlag' : 'ClearFlag'] = xrpl.AccountSetAsfFlags[flagKey];
+                        tx[(flagValue) ? 'SetFlag' : 'ClearFlag'] |= xrpl.AccountSetAsfFlags[flagKey];
                     }
                     break;
 


### PR DESCRIPTION
In order to disable Master Key pair **AccountSet** Transaction should be performed on the account with a special flag. Hence a custom helper method was added to fulfill that requirement. 