### PR TITLE
Adding version in host update reg info.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "evernode-js-client",
-    "version": "0.4.29",
+    "version": "0.4.30",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evernode-js-client",
-    "version": "0.4.30",
+    "version": "0.4.31",
     "scripts": {
         "lint": "./node_modules/.bin/eslint src/**/*.js",
         "build": "npm run lint && ncc build src/index.js -e elliptic -e xrpl -e ripple-address-codec -e ripple-keypairs -o dist/",

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -233,8 +233,8 @@ class HostClient extends BaseEvernodeClient {
         return await this.isRegistered();
     }
 
-    async updateRegInfo(activeInstanceCount = null, totalInstanceCount = null, tokenID = null, countryCode = null, cpuMicroSec = null, ramMb = null, diskMb = null, description = null, options = {}) {
-        const dataStr = `${tokenID ? tokenID : ''};${countryCode ? countryCode : ''};${cpuMicroSec ? cpuMicroSec : ''};${ramMb ? ramMb : ''};${diskMb ? diskMb : ''};${totalInstanceCount ? totalInstanceCount : ''};${activeInstanceCount !== undefined ? activeInstanceCount : ''};${description ? description : ''}`;
+    async updateRegInfo(activeInstanceCount = null, version = null, totalInstanceCount = null, tokenID = null, countryCode = null, cpuMicroSec = null, ramMb = null, diskMb = null, description = null, options = {}) {
+        const dataStr = `${tokenID ? tokenID : ''};${countryCode ? countryCode : ''};${cpuMicroSec ? cpuMicroSec : ''};${ramMb ? ramMb : ''};${diskMb ? diskMb : ''};${totalInstanceCount ? totalInstanceCount : ''};${activeInstanceCount !== undefined ? activeInstanceCount : ''};${description ? description : ''};${version ? version : ''}`;
         return await this.xrplAcc.makePayment(this.registryAddress,
             XrplConstants.MIN_XRP_AMOUNT,
             XrplConstants.XRP,

--- a/src/state-helpers.js
+++ b/src/state-helpers.js
@@ -16,6 +16,7 @@ const HOST_REG_FEE_OFFSET = 88;
 const HOST_TOT_INS_COUNT_OFFSET = 96;
 const HOST_ACT_INS_COUNT_OFFSET = 100;
 const HOST_HEARTBEAT_LEDGER_IDX_OFFSET = 104;
+const HOST_VERSION_OFFSET = 112;
 
 class StateHelpers {
     static StateTypes = {
@@ -38,7 +39,8 @@ class StateHelpers {
             registrationFee: Number(stateDataBuf.readBigUInt64BE(HOST_REG_FEE_OFFSET)),
             noOfTotalInstances: stateDataBuf.readUInt32BE(HOST_TOT_INS_COUNT_OFFSET),
             noOfActiveInstances: stateDataBuf.readUInt32BE(HOST_ACT_INS_COUNT_OFFSET),
-            lastHeartbeatLedger: Number(stateDataBuf.readBigUInt64BE(HOST_HEARTBEAT_LEDGER_IDX_OFFSET))
+            lastHeartbeatLedger: Number(stateDataBuf.readBigUInt64BE(HOST_HEARTBEAT_LEDGER_IDX_OFFSET)),
+            version: `${stateDataBuf.readUInt8(HOST_VERSION_OFFSET)}.${stateDataBuf.readUInt8(HOST_VERSION_OFFSET + 1)}.${stateDataBuf.readUInt8(HOST_VERSION_OFFSET + 2)}`
         }
     }
 


### PR DESCRIPTION
- The version field from the state is decoded and the firestore is updated in 1.2.3 format.
- Version is included in the updateRegInfo call in HostClient.


